### PR TITLE
Ensure JSON URL has trailing slash

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,7 +17,7 @@ function bbdemo_include_scripts() {
 	if ( false !== strpos( $request_uri, '/demo1' ) ) {
 		$scriptname = 'backbonedemo1.js';
 		$demodata = array(
-			'apiurl' => get_json_url(), /* Pass the WP REST API url */
+			'apiurl' => trailingslashit( get_json_url() ), /* Pass the WP REST API url */
 		);
 	} elseif ( false !== strpos( $request_uri, '/demo2' ) )  {
 		$scriptname = 'backbonedemo2.js';
@@ -26,7 +26,7 @@ function bbdemo_include_scripts() {
 				'no_count_posts' => true,
 			) );
 		$demodata   = array(
-			'apiurl' => get_json_url(), /* Pass the WP REST API url */
+			'apiurl' => trailingslashit( get_json_url() ), /* Pass the WP REST API url */
 			'posts'  => $post_data,
 		);
 


### PR DESCRIPTION
I was getting 404s from URLs like `/wp-jsonposts/1` in both demos. Not sure how consistent trailing slash/ lack of trailing slash will be, hence my use of `trailingslashit()`
